### PR TITLE
Example script does not exit properly if autoloader was not found.

### DIFF
--- a/example
+++ b/example
@@ -17,7 +17,8 @@ if ($pharPath) {
     } elseif (file_exists(__DIR__.'/../../autoload.php')) {
         $autoloaderPath = __DIR__ . '/../../autoload.php';
     } else {
-        die("Could not find autoloader. Run 'composer install'.");
+        echo ("Could not find autoloader. Run 'composer install'.");
+        exit(1);
     }
 }
 $classLoader = require $autoloaderPath;


### PR DESCRIPTION
### Overview
This pull request changes the `example` script to use `exit(`)` so that a proper return code is generated when autoload fails.

It turns out that this does not exit with a non-zero exit code:

```php
die("You would think this would bubble up a failure, but it won't");
exit("Might also think that passing a string like this to 'exit' would also behave like a 'non-zero' code, but it won't.");
# Is this really the only way to pass a non-zero exit code? ¯\_(ツ)_/¯
exit(1)

```


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary
Use `echo` to show a message, and `exit(1)` to ensure a proper exit code is returned to the calling script.

