### PR TITLE
Resolves #20: Filter package name based on Packagist requirements

### DIFF
--- a/tests/unit/Customizer/CustomizerTest.php
+++ b/tests/unit/Customizer/CustomizerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ExampleProject\unit\Customizer;
+
+use CustomizeProject\Customizer;
+use PHPUnit\Framework\TestCase;
+
+class CustomizerTest extends TestCase
+{
+
+    /**
+     * @test
+     */
+    public function itEnsuresValidComposerProjectNames()
+    {
+        $customizer = new Customizer();
+        $pascalExample = 'CoolCorp/LeetNinja!';
+        $this->assertEquals(
+            'coolcorp/leetninja',
+            $customizer->formatNameForPackagist($pascalExample)
+        );
+        $camelExample = 'coolCorp/LeetNinja!';
+        $this->assertEquals(
+            'coolcorp/leetninja',
+            $customizer->formatNameForPackagist($camelExample)
+        );
+        $kebabExample = 'cool-corp@/leet-ninja!';
+        $this->assertEquals(
+            'cool-corp/leet-ninja',
+            $customizer->formatNameForPackagist($kebabExample)
+        );
+        $numericExample = 'cool-corp1/leet-ninja4';
+        $this->assertEquals(
+            'cool-corp1/leet-ninja4',
+            $customizer->formatNameForPackagist($numericExample)
+        );
+    }
+}


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Has tests?    | yes
| BC breaks?    | no     
| Deprecations? | yes

### Summary
This filters out invalid characters before modifying the composer package name.

### Description
Any additional information.
